### PR TITLE
LXC/Android 8.1 backups into /home/nemo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Overview of the steps performed by the scripts:
  * deodex using [simple-deodexer](https://github.com/aureljared/simple-deodexer) on non LXC system (android 4.4)
  * deodex using [vdexExtractor](https://github.com/anestisb/vdexExtractor) on LXC system (android 8.1)
  * apply `hook` and `core` patches from [haystack](https://github.com/Lanchon/haystack)
- * push back changed files, saving backups in `/opt/alien/system/{framework,app,priv-app}.pre_haystack` (nonLXC/android 4.4) or `/opt/alien/system.img.pre.haystack` (LXC/android 8.1)
+ * push back changed files, saving backups in `/opt/alien/system/{framework,app,priv-app}.pre_haystack` (nonLXC/android 4.4) or `/home/nemo/system.img.pre.haystack` (LXC/android 8.1)
 
 Instructions
 ===

--- a/run.sh
+++ b/run.sh
@@ -73,6 +73,7 @@ if [ "${LXC}" -eq 1 ]; then
 
     echo [**] 5. Upload results back
     rsync -va --delete-after -b --suffix=".pre_haystack" \
+        --backup-dir=../../home/nemo \
         /tmp/system.img.haystack \
         rsync://${SAILFISH}/alien/system.img
 


### PR DESCRIPTION
If backups are done to /opt/alien, then disk space for
/opt runs out and update fails unless user remembers
to remove backups before updating.